### PR TITLE
進捗報告の期限切れの表示

### DIFF
--- a/lib/home/home_page.dart
+++ b/lib/home/home_page.dart
@@ -40,7 +40,7 @@ class HomePage extends ConsumerWidget {
                 TaskProgressPost(
                   progress: progress,
                 ),
-                const Gap(8),
+                const Gap(16),
               },
             ],
           ),


### PR DESCRIPTION
進捗報告画面で、過去の週のタスクに対する進捗報告へ「期限切れ」が正しく表示されるように修正しました。
進捗報告画面のデザインを少し修正しました。